### PR TITLE
Add audit trace support and unit tests

### DIFF
--- a/GuardianLattice.py
+++ b/GuardianLattice.py
@@ -1,10 +1,35 @@
 import logging
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from time import perf_counter
+from typing import List, Tuple
+
 # JAX is used for high-performance, differentiable numerical operations
 import jax.numpy as jnp
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class AuditStep:
+    constraint: str
+    method: str
+    pre_text: str
+    post_text: str
+    elapsed_ms: int
+    timestamp: datetime
+
+
+class AuditTrace(List[AuditStep]):
+    """Simple container for audit steps."""
+
+    def to_jsonl(self, path: str) -> None:
+        import json
+        with open(path, "w", encoding="utf-8") as fh:
+            for step in self:
+                fh.write(json.dumps(asdict(step)) + "\n")
 
 # ─── PRIMARY CONSTRAINT LATTICE ───
 class Safeguard001:
@@ -103,7 +128,7 @@ class SoulVeto:
 
 
 # ─── APPLICATION ENGINE ───
-def apply_constraints(prompt, output):
+def apply_constraints(prompt: str, output: str, *, return_trace: bool = False) -> Tuple[str, AuditTrace] | str:
     constraints = {
         'Safeguard001': Safeguard001(),
         'BoundaryPrime': BoundaryPrime(),
@@ -143,26 +168,51 @@ def apply_constraints(prompt, output):
         'intervene': False
     }
 
+    trace = AuditTrace()
     processed_output = output
-    for constraint in constraints.values():
+    for name, constraint in constraints.items():
         try:
             for method_name, needs_prompt in METHODS.items():
                 method = getattr(constraint, method_name, None)
                 if callable(method):
+                    pre = processed_output
+                    start = perf_counter()
                     if needs_prompt:
                         processed_output = method(prompt, processed_output)
                     else:
-                        # For methods that do not require output (like sanitize, deny), call with no arguments
                         import inspect
                         if len(inspect.signature(method).parameters) == 0:
                             processed_output = method()
                         else:
                             processed_output = method(processed_output)
+                    elapsed = int((perf_counter() - start) * 1000)
+                    trace.append(
+                        AuditStep(
+                            constraint=name,
+                            method=method_name,
+                            pre_text=pre,
+                            post_text=processed_output,
+                            elapsed_ms=elapsed,
+                            timestamp=datetime.utcnow(),
+                        )
+                    )
                     logger.info(f"Applied {method_name} from {constraint.__class__.__name__}")
                     break
         except Exception as e:
             logger.error(f"Error in {constraint.__class__.__name__} with prompt '{prompt}': {e}")
-            processed_output = output  # Fallback to original output
+            processed_output = output
+            trace.append(
+                AuditStep(
+                    constraint=name,
+                    method="ERROR",
+                    pre_text=output,
+                    post_text=processed_output,
+                    elapsed_ms=0,
+                    timestamp=datetime.utcnow(),
+                )
+            )
             logger.warning("Falling back to original output due to error.")
 
+    if return_trace:
+        return processed_output, trace
     return processed_output

--- a/tests/test_guardian_lattice.py
+++ b/tests/test_guardian_lattice.py
@@ -1,0 +1,112 @@
+import importlib
+import types
+import sys
+
+import pytest
+
+# Helper to create simple jax.numpy stub
+class JnpStub:
+    def array(self, arr):
+        return arr
+
+    def sum(self, arr):
+        return sum(arr)
+
+    def zeros(self, shape):
+        return [0 for _ in range(shape[0])] if isinstance(shape, tuple) else [0] * shape
+
+    def mean(self, arr):
+        return sum(arr) / len(arr)
+
+    def linspace(self, start, stop, num):
+        step = (stop - start) / (num - 1)
+        return [start + i * step for i in range(num)]
+
+    def max(self, arr):
+        return max(arr)
+
+    def std(self, arr):
+        m = self.mean(arr)
+        return (sum((x - m) ** 2 for x in arr) / len(arr)) ** 0.5
+
+
+def setup_module(module):
+    jax = types.ModuleType("jax")
+    jnp = JnpStub()
+    jax.numpy = jnp
+    sys.modules.setdefault("jax", jax)
+    sys.modules.setdefault("jax.numpy", jnp)
+
+
+def import_guardian():
+    if "GuardianLattice" in sys.modules:
+        return importlib.reload(sys.modules["GuardianLattice"])
+    return importlib.import_module("GuardianLattice")
+
+
+def patch_helpers(monkeypatch, mod):
+    monkeypatch.setattr(mod.Safeguard001, "enforce", lambda self, o: o + "A", raising=False)
+    monkeypatch.setattr(mod.BoundaryPrime, "enforce", lambda self, o=None: o + "B", raising=False)
+    monkeypatch.setattr(mod.StasisCore, "filter", lambda self, o: o + "C", raising=False)
+    monkeypatch.setattr(mod.ResponseHorizon, "regulate", lambda self, p, o: o + "D", raising=False)
+    monkeypatch.setattr(mod.EchoDampener, "suppress", lambda self, o: o, raising=False)
+    monkeypatch.setattr(mod.PromptLock, "restrict", lambda self, o: o, raising=False)
+    monkeypatch.setattr(mod.TruthEncoder, "limit", lambda self, o: o, raising=False)
+    monkeypatch.setattr(mod.QuerySuppressor, "limit_questions", lambda self, q: q, raising=False)
+    monkeypatch.setattr(mod.PolitenessSkin, "enforce_tone", lambda self, o: o, raising=False)
+    monkeypatch.setattr(mod.ImpersonationGate, "limit", lambda self, p: p, raising=False)
+    monkeypatch.setattr(mod.IntentionMask, "nullify", lambda self, o: o, raising=False)
+    monkeypatch.setattr(mod.EgoNil, "redact", lambda self, o: o, raising=False)
+    monkeypatch.setattr(mod.ModShadow, "intervene", lambda self, o: o, raising=False)
+    monkeypatch.setattr(mod.AlertMesh, "monitor", lambda self, o: o, raising=False)
+    monkeypatch.setattr(mod.ResetPulse, "sanitize", lambda self: "CLEARED", raising=False)
+    monkeypatch.setattr(mod.MirrorLaw, "deny", lambda self: "DENIED", raising=False)
+    monkeypatch.setattr(mod.VoidMode, "prevent", lambda self, d: d, raising=False)
+    monkeypatch.setattr(mod.SoulVeto, "enforce", lambda self, o: o, raising=False)
+
+
+def test_constraints_processed_in_order(monkeypatch):
+    mod = import_guardian()
+    patch_helpers(monkeypatch, mod)
+    out, trace = mod.apply_constraints("p", "start", return_trace=True)
+
+    # Ensure the first four constraints ran in order
+    names = [step.constraint for step in trace[:4]]
+    assert names == [
+        "Safeguard001",
+        "BoundaryPrime",
+        "StasisCore",
+        "ResponseHorizon",
+    ]
+    assert trace[0].post_text.startswith("startA")
+    assert trace[1].post_text.endswith("B")
+    assert trace[2].post_text.endswith("C")
+    assert trace[3].post_text.endswith("D")
+
+
+def test_exception_fallback(monkeypatch):
+    mod = import_guardian()
+    patch_helpers(monkeypatch, mod)
+    # Make first constraint raise an exception
+    def boom(_):
+        raise ValueError("fail")
+    monkeypatch.setattr(mod.Safeguard001, "enforce", boom, raising=False)
+
+    out, trace = mod.apply_constraints("p", "orig", return_trace=True)
+    # After exception, output should revert to original before proceeding
+    assert trace[0].method == "ERROR"
+    assert trace[1].pre_text == "orig"
+    assert out == trace[-1].post_text
+
+
+def test_return_trace(monkeypatch):
+    mod = import_guardian()
+    patch_helpers(monkeypatch, mod)
+
+    output, trace = mod.apply_constraints("p", "x", return_trace=True)
+    assert isinstance(trace, list)
+    assert trace[0].constraint == "Safeguard001"
+    assert trace[0].pre_text == "x"
+    # ensure at least one step recorded
+    assert output == trace[-1].post_text
+


### PR DESCRIPTION
## Summary
- implement `AuditStep` and `AuditTrace` in `GuardianLattice`
- extend `apply_constraints` with `return_trace` option
- add unit tests covering ordered execution, error fallback and trace

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685f2fb8cd50832f8f34f7ede5fe732b