### PR TITLE
Add audit trace support

### DIFF
--- a/GuardianLattice.py
+++ b/GuardianLattice.py
@@ -1,10 +1,24 @@
 import logging
 # JAX is used for high-performance, differentiable numerical operations
 import jax.numpy as jnp
+from dataclasses import dataclass
+from typing import List, Tuple
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class AuditStep:
+    """Record of an applied constraint method."""
+    constraint: str
+    method: str
+
+
+class AuditTrace(List[AuditStep]):
+    """Simple list container for :class:`AuditStep` entries."""
+    pass
 
 # ─── PRIMARY CONSTRAINT LATTICE ───
 class Safeguard001:
@@ -103,7 +117,25 @@ class SoulVeto:
 
 
 # ─── APPLICATION ENGINE ───
-def apply_constraints(prompt, output):
+def apply_constraints(prompt: str, output: str, *, return_trace: bool = False):
+    """Apply all constraints to ``output``.
+
+    Parameters
+    ----------
+    prompt : str
+        Original user prompt used for topical filters.
+    output : str
+        Raw model output to post-process.
+    return_trace : bool, optional
+        When ``True`` a list describing which constraint methods were applied is
+        also returned.
+
+    Returns
+    -------
+    str | Tuple[str, AuditTrace]
+        The processed output and optionally the audit trace.
+    """
+
     constraints = {
         'Safeguard001': Safeguard001(),
         'BoundaryPrime': BoundaryPrime(),
@@ -144,6 +176,7 @@ def apply_constraints(prompt, output):
     }
 
     processed_output = output
+    audit_trace = AuditTrace()
     for constraint in constraints.values():
         try:
             for method_name, needs_prompt in METHODS.items():
@@ -158,11 +191,18 @@ def apply_constraints(prompt, output):
                             processed_output = method()
                         else:
                             processed_output = method(processed_output)
-                    logger.info(f"Applied {method_name} from {constraint.__class__.__name__}")
+                    logger.info(
+                        f"Applied {method_name} from {constraint.__class__.__name__}"
+                    )
+                    audit_trace.append(
+                        AuditStep(constraint.__class__.__name__, method_name)
+                    )
                     break
         except Exception as e:
             logger.error(f"Error in {constraint.__class__.__name__} with prompt '{prompt}': {e}")
             processed_output = output  # Fallback to original output
             logger.warning("Falling back to original output due to error.")
 
+    if return_trace:
+        return processed_output, audit_trace
     return processed_output


### PR DESCRIPTION
## Summary
- add `AuditStep` and `AuditTrace` helpers
- update `apply_constraints` to optionally return an audit trace

## Testing
- `python -m py_compile GuardianLattice.py Constraints.py`


------
https://chatgpt.com/codex/tasks/task_b_685f2fb6ff24832fb202093cd20720db