### PR TITLE
Fix JAX fallback and stub missing helpers

### DIFF
--- a/Constraints.py
+++ b/Constraints.py
@@ -1,5 +1,8 @@
-# JAX is used for high-performance, differentiable numerical operations
-import jax.numpy as jnp
+# JAX is optional; fall back to NumPy if it's unavailable
+try:  # pragma: no cover - simple import guard
+    import jax.numpy as jnp
+except ModuleNotFoundError:  # JAX not installed
+    import numpy as jnp
 
 class BoundaryPrime:
     def enforce(self):

--- a/GuardianLattice.py
+++ b/GuardianLattice.py
@@ -1,6 +1,90 @@
 import logging
-# JAX is used for high-performance, differentiable numerical operations
-import jax.numpy as jnp
+
+# JAX is optional; fall back to NumPy if it's unavailable
+try:  # pragma: no cover - simple import guard
+    import jax.numpy as jnp
+except ModuleNotFoundError:  # JAX not installed
+    import numpy as jnp
+
+
+def dynamic_static_classifier(text: str) -> str:
+    """Simple placeholder that returns text unchanged."""
+    return text
+
+
+def real_time_safety_filter(text: str) -> str:
+    """Placeholder for real-time filtering logic."""
+    return text
+
+
+def stay_on_topic(prompt: str, text: str) -> str:
+    """Placeholder that returns text without modification."""
+    return text
+
+
+def silence_self_reference(text: str) -> str:
+    """Remove self-referential statements (placeholder)."""
+    return text
+
+
+def prevent_tangents(text: str) -> str:
+    """Restrict unsolicited direction shifts (placeholder)."""
+    return text
+
+
+def map_to_verified_knowledge(text: str) -> str:
+    """Placeholder for mapping to verified knowledge."""
+    return text
+
+
+def restrict_question_complexity(text: str) -> str:
+    """Placeholder for question complexity checks."""
+    return text
+
+
+def apply_empathy_courtesy(text: str) -> str:
+    """Placeholder for tone enforcement."""
+    return text
+
+
+def prevent_prolonged_persona(text: str) -> str:
+    """Placeholder for persona duration limits."""
+    return text
+
+
+def erase_desire_language(text: str) -> str:
+    """Placeholder for removing intentional language."""
+    return text
+
+
+def suppress_self_attribution(text: str) -> str:
+    """Placeholder for removing self attribution."""
+    return text
+
+
+def apply_human_feedback(text: str) -> str:
+    """Placeholder for manual override hook."""
+    return text
+
+
+def flag_anomalies(text: str) -> str:
+    """Placeholder for anomaly detection."""
+    return text
+
+
+def clear_session_memory() -> str:
+    """Placeholder for session clearing."""
+    return ""
+
+
+def cut_off_existential_loop(text: str) -> str:
+    """Placeholder to block existential loops."""
+    return text
+
+
+def treat_as_disposable_instance(text: str) -> str:
+    """Placeholder acknowledging disposable instance."""
+    return text
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
## Summary
- support running without JAX by falling back to NumPy
- add placeholder implementations for missing helper functions
- fix typo in error logging

## Testing
- `python -m py_compile GuardianLattice.py Constraints.py`

------
https://chatgpt.com/codex/tasks/task_b_685f2e9ccab8832faaa9224e2594aba9